### PR TITLE
Add account-orgchart recipe for building interactive org charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Without Deepline, you'd need to:
 | [`linkedin-url-lookup`](skills/linkedin-url-lookup/SKILL.md) | Resolve LinkedIn profile URLs from name+company with nickname handling and Apify verification |
 | [`clay-to-deepline`](skills/clay-to-deepline/SKILL.md) | Migrate Clay table configurations to local Deepline enrichment scripts — schema analysis, dependency graph, and script generation |
 
+### Recipes (not auto-invoked)
+
+These are reference playbooks you can ask for explicitly. They don't trigger automatically.
+
+| Recipe | What it does |
+|---|---|
+| [`account-orgchart`](skills/account-orgchart/SKILL.md) | Build an interactive HTML org chart - map reporting structures, identify decision makers, highlight warm intro paths |
+
 ---
 
 ## Prerequisites

--- a/skills/account-orgchart/SKILL.md
+++ b/skills/account-orgchart/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: account-orgchart
+description: "Build an interactive org chart around a target person or company using Deepline CLI. Maps reporting structures, identifies decision makers, and highlights warm intro paths."
+---
+
+# Account Org Chart Builder
+
+Build an interactive HTML org chart for account mapping - find decision makers, map reporting structures, and identify warm intro paths.
+
+This is a **recipe** (not auto-invoked). Reference it when:
+- User asks to "map an account" or "build an org chart"
+- User wants to find "who reports to X" or "decision makers at Y"
+- User has a warm connection and wants to find paths through the org
+
+## Inputs
+
+One of:
+- LinkedIn URL (+ optional company/domain)
+- Name + company name or domain
+- Just a company domain (maps the full GTM org)
+
+If only a name is given with no company context, ask before proceeding.
+
+## Quick reference
+
+| Step | What | Source | Cost |
+|------|------|--------|------|
+| 1 | Resolve target | `leadmagic_profile_search` or `person_enrichment_from_email_waterfall` | 1 credit |
+| 2a | Deepline Native search | `deepline_native_search_contact` (4 title tiers) | $0.04/req |
+| 2b | Dropleads search | `dropleads_search_people` | FREE |
+| 2c | Apify LinkedIn scrape | `apimaestro/linkedin-company-employees-scraper-no-cookies` | ~$0.25 |
+| 2d | Apollo paid search | `apollo_people_search_paid` (2 pages) | ~$5 |
+| 2e | PDL gap-fill (optional) | `peopledatalabs_person_search` CXO+VP only | ~$2-11 |
+| 3 | Classify + infer | Title-based seniority + Claude reasoning for hierarchy | 0 |
+| 4 | Generate output | HTML org chart file | 0 |
+
+Typical run: 150-250 people found, ~$7-16 total, 3-8 minutes.
+
+**Cost-optimal order:** Free first (DN + Dropleads), then cheap (Apify), then paid (Apollo), then surgical (PDL for missing execs only). Each step deduplicates against prior results.
+
+## Pipeline
+
+### 1. Resolve target identity
+
+**If LinkedIn URL given:**
+```bash
+deepline enrich --input seed.csv --in-place \
+  --with '{"alias":"target_profile","tool":"leadmagic_profile_search","payload":{"profile_url":"{{linkedin_url}}"},"extract_js":"(data) => ({ name: (data?.first_name || \"\") + \" \" + (data?.last_name || \"\"), title: data?.current_position || data?.headline || \"\", company_name: data?.current_company || \"\", location: data?.location || \"\" })"}'
+```
+
+Then resolve domain if missing:
+```bash
+deepline enrich --input seed.csv --in-place \
+  --with '{"alias":"domain_search","tool":"exa_search","payload":{"query":"{{company_name}} official website","numResults":1}}'
+deepline enrich --input seed.csv --in-place \
+  --with '{"alias":"domain","tool":"run_javascript","payload":{"code":"const r=row.domain_search;const url=(((r&&r.data&&r.data.results||[])[0])||{}).url||\"\";const m=url.match(/^https?:\\/\\/(www\\.)?([^\\/]+)/);return m?m[2]:null;"}}'
+```
+
+**If name + company given:**
+Create seed CSV with columns: `name`, `company_name`, `domain`. If no domain, resolve with exa_search as above.
+
+### 2. Find ALL employees (cost-optimal waterfall)
+
+Run sources cheapest-first. Each step deduplicates against prior results - only net-new people advance.
+
+```bash
+WORK_DIR="output/orgchart/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$WORK_DIR"
+echo "company_domain,company_name" > "$WORK_DIR/accounts.csv"
+echo "\"$DOMAIN\",\"$COMPANY\"" >> "$WORK_DIR/accounts.csv"
+```
+
+**Source 1: Deepline Native ($0.04/request)**
+```bash
+deepline enrich --input "$WORK_DIR/accounts.csv" --output "$WORK_DIR/dn-csuite.csv" \
+  --with '{"alias":"people","tool":"deepline_native_search_contact","payload":{"domain":"{{company_domain}}","title_filters":[{"name":"csuite","filter":"CEO OR CTO OR CFO OR COO OR CMO OR CRO OR Founder"}]}}'
+deepline enrich --input "$WORK_DIR/accounts.csv" --output "$WORK_DIR/dn-vp.csv" \
+  --with '{"alias":"people","tool":"deepline_native_search_contact","payload":{"domain":"{{company_domain}}","title_filters":[{"name":"vp","filter":"VP OR Vice President OR SVP"}]}}'
+deepline enrich --input "$WORK_DIR/accounts.csv" --output "$WORK_DIR/dn-dir.csv" \
+  --with '{"alias":"people","tool":"deepline_native_search_contact","payload":{"domain":"{{company_domain}}","title_filters":[{"name":"dir","filter":"Head OR Director OR Senior Director"}]}}'
+deepline enrich --input "$WORK_DIR/accounts.csv" --output "$WORK_DIR/dn-mgr.csv" \
+  --with '{"alias":"people","tool":"deepline_native_search_contact","payload":{"domain":"{{company_domain}}","title_filters":[{"name":"mgr","filter":"Manager OR Senior Manager"}]}}'
+```
+Expected: ~25-35 people.
+
+**Source 2: Dropleads (FREE)**
+```bash
+deepline enrich --input "$WORK_DIR/accounts.csv" --output "$WORK_DIR/dropleads.csv" \
+  --with '{"alias":"people","tool":"dropleads_search_people","payload":{"filters":{"companyDomains":["{{company_domain}}"]},"pagination":{"page":1,"limit":100}}}'
+```
+Expected: +60-80 net new.
+
+**Source 3: Apify LinkedIn scrape (~$0.25)**
+
+First resolve the LinkedIn company slug:
+```bash
+deepline tools execute exa_search --payload '{"query":"COMPANY_NAME LinkedIn company page site:linkedin.com/company","numResults":1,"type":"auto"}'
+```
+Then scrape employees:
+```bash
+deepline tools execute apify_run_actor_sync --payload '{"actorId":"apimaestro/linkedin-company-employees-scraper-no-cookies","input":{"identifier":"https://www.linkedin.com/company/SLUG/","max_employees":500}}'
+```
+Results use `fullname` (not `fullName`), `headline` (not `title`), `profile_url`. Expected: +15-25 net new.
+
+**Source 4: Apollo paid search (~$5)**
+```bash
+deepline tools execute apollo_people_search_paid --payload '{"q_organization_domains_list":["DOMAIN"],"per_page":100,"page":1}'
+deepline tools execute apollo_people_search_paid --payload '{"q_organization_domains_list":["DOMAIN"],"per_page":100,"page":2}'
+```
+Expected: +80-100 net new.
+
+**Source 5: PDL surgical gap-fill - ONLY for missing senior people**
+
+After building initial hierarchy, identify gaps (e.g., "5 Sales Directors but no VP Sales"):
+```bash
+deepline tools execute peopledatalabs_person_search --payload '{"size":30,"sql":"SELECT * FROM person WHERE job_company_website = '\''DOMAIN'\'' AND (job_title_levels = '\''cxo'\'' OR job_title_levels = '\''vp'\'')"}'
+```
+PDL costs 3.92 credits/result. Pull CXO+VP only (~29 people, ~$11) then dedupe.
+
+Merge all results, deduplicate by slugified name.
+
+### 3. Classify seniority + infer hierarchy
+
+Apply seniority classification from `references/hierarchy-rules.md`:
+
+| Rank | Level | Patterns |
+|------|-------|----------|
+| 0 | ceo | "ceo", "chief executive" |
+| 1 | c-level | "chief" + any (cto, cfo, coo, cmo, cro) |
+| 2 | evp | "evp", "executive vice president" |
+| 3 | svp | "svp", "senior vice president" |
+| 4 | vp | "vice president", "vp", "area vice president" |
+| 5 | sr-director | "senior director" |
+| 6 | director | "head of", "director" |
+| 7 | sr-manager | "senior manager" |
+| 8 | manager | "manager" |
+| 9 | principal | "principal", "staff" |
+| 10 | lead | "lead" |
+| 11 | senior | "senior", "sr." |
+| 12 | ic | everything else |
+
+For display, simplify to 4 levels:
+- **exec**: ceo, c-level, evp, svp, vp
+- **director**: sr-director, director
+- **manager**: sr-manager, manager, principal, lead
+- **ic**: senior, ic
+
+Infer teams from title patterns (text after comma).
+
+### 4. Generate HTML org chart
+
+Use the template at `references/orgchart-template.html`. Key design elements:
+
+**Design system (avoid AI slop):**
+- Dark mode: `--bg: #0a0a0a`, `--surface: #141414`, `--border: #262626`
+- Text: `--text: #e5e5e5`, `--text-muted: #a3a3a3`
+- Warm path: `--warm: #f59e0b` with amber glow
+- Seniority colors: Exec=#a78bfa, Director=#60a5fa, Manager=#34d399, IC=#525252
+
+**Critical UX elements:**
+- **Warm path banner** at top if user has a connection
+- **Priority score column** (0-100): +40 exec, +25 director, +10 manager, +25 email, +10 phone, +30 warm
+- **Clickable stats bar** with percentages that filter on click
+- **Team sidebar** (left): collapsed teams with counts
+- **Table layout**: sortable by priority
+- **Empty state** with "Clear all filters" button
+- Keyboard: `/` to focus search, `Esc` to close modal
+
+**What to avoid:**
+- Rainbow of 13+ seniority badge colors
+- 14+ teams without grouping
+- Stats that just count things (show percentages)
+- Gray text below 4.5:1 contrast
+- Jargon badges like "ZoomInfo Likely"
+
+Save to `output/orgchart/{company}-{target}-{date}.html`.
+
+## Manager prediction scoring
+
+```
+score = seniority_gap + team_match + geo + experience_delta
+```
+
+| Factor | Condition | Score |
+|--------|-----------|-------|
+| Seniority gap | Exactly 1 level above | +10 |
+| Seniority gap | 2 levels above | +5 |
+| Team match | Same team | +8 |
+| Team match | Related (substring) | +3 |
+| Geo | Same city | +2 |
+| Experience | 3+ more years | +2 |
+
+Highest score wins. Min threshold: 5.
+
+## When NOT to use
+
+- User already has a CSV and wants enrichment -> use gtm-meta-skill
+- User needs email/phone for outreach -> this skill maps orgs, use gtm-meta-skill for contact info after

--- a/skills/account-orgchart/references/hierarchy-rules.md
+++ b/skills/account-orgchart/references/hierarchy-rules.md
@@ -1,0 +1,96 @@
+# Hierarchy Inference Rules
+
+## Seniority classification (internal, 13 levels)
+
+| Rank | Level | Patterns (check in order, first match wins) |
+|------|-------|---------------------------------------------|
+| 0 | ceo | "ceo", "chief executive" |
+| 1 | c-level | "chief" + any (cto, cfo, coo, cmo, cro, cpo, cao, cio) |
+| 2 | evp | "evp", "executive vice president" |
+| 3 | svp | "svp", "senior vice president" |
+| 4 | vp | "vice president", word-boundary "vp", "area vice president", "avp" |
+| 5 | sr-director | "senior director" |
+| 6 | director | "head of", "head,", "director" |
+| 7 | sr-manager | "senior manager", "group product manager" |
+| 8 | manager | "manager" |
+| 9 | principal | "principal", "staff" |
+| 10 | lead | "lead" |
+| 11 | senior | "senior", "sr." |
+| 12 | ic | everything else |
+
+## Display seniority (for UI, 4 levels)
+
+For rendering in the org chart, simplify to 4 visual levels:
+
+| Display | Internal levels | Color |
+|---------|-----------------|-------|
+| exec | ceo, c-level, evp, svp, vp | #a78bfa |
+| director | sr-director, director | #60a5fa |
+| manager | sr-manager, manager, principal, lead | #34d399 |
+| ic | senior, ic | #525252 |
+
+## Manager prediction scoring
+
+```
+score = seniority_gap + team_match + geo + experience_delta
+```
+
+| Factor | Condition | Score |
+|--------|-----------|-------|
+| Seniority gap | Exactly 1 level above | +10 |
+| Seniority gap | 2 levels above | +5 |
+| Seniority gap | 3 levels above | +2 |
+| Seniority gap | 4+ levels | +1 |
+| Seniority gap | Same or below | Skip |
+| Team match | Same team | +8 |
+| Team match | Related (substring) | +3 |
+| Geo | Same city | +2 |
+| Geo | Same country | +1 |
+| Experience | 3+ more years | +2 |
+| Experience | 8+ more years | +3 (replaces +2) |
+
+Highest score wins. Min threshold: 5.
+
+## Peers
+
+Same seniority rank, excluding self.
+
+## Direct reports
+
+1-2 levels below target. Prefer same team. Gap of 1 with no team info still counts.
+
+## Team from title
+
+"Director of Engineering, Identity" -> team = "Identity" (text after comma).
+Filter out: Sr, Jr, II, III, Senior, Junior, Lead, Staff, Principal.
+
+## Confidence
+
+3+ sources: high. 2: medium. 1: low.
+
+## Building the hierarchy
+
+1. Find target's most likely manager (highest scoring candidate)
+2. Walk upward: find manager's manager, repeat until no senior candidate or score < 5
+3. Topmost person = root
+4. Find target's peers (same seniority)
+5. Find target's direct reports (1-2 below, same team preferred)
+6. Peers go under same manager as target
+7. Build edges: parent -> [children]
+8. Prune unconnected nodes
+
+## Team consolidation
+
+When original data has >8 teams, consolidate into 5-6 groups:
+
+| Original | Simplified |
+|----------|------------|
+| Executive Leadership, Office of CEO | Leadership |
+| Sales, GTM, Business Development | Sales |
+| Revenue Operations, Sales Operations, GTM Ops | Revenue Ops |
+| Sales Enablement, Enablement | Enablement |
+| GTM Strategy, Strategy | Strategy |
+| Marketing, Demand Gen, Product Marketing | Marketing |
+| Customer Success, Support | Customer Success |
+| AI, Product, Engineering, Data, Analytics | Product & Eng |
+| HR, People, Finance, Legal | Other |

--- a/skills/account-orgchart/references/orgchart-template.html
+++ b/skills/account-orgchart/references/orgchart-template.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{COMPANY}} - Account Map</title>
+    <style>
+        /* Design tokens - use these exactly */
+        :root {
+            --bg: #0a0a0a;
+            --surface: #141414;
+            --surface-2: #1c1c1c;
+            --border: #262626;
+            --text: #e5e5e5;
+            --text-muted: #a3a3a3;
+            --text-dim: #737373;
+            --accent: #3b82f6;
+            --warm: #f59e0b;
+            --warm-glow: rgba(245, 158, 11, 0.15);
+            --success: #22c55e;
+            --warning: #eab308;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            padding: 24px;
+            line-height: 1.5;
+        }
+
+        /* Warm intro banner - REQUIRED when user has a connection */
+        .warm-banner {
+            background: var(--warm-glow);
+            border: 1px solid var(--warm);
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 20px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+        .warm-banner-name { font-weight: 600; color: var(--warm); }
+        .warm-banner-action {
+            background: var(--warm);
+            color: #000;
+            padding: 6px 12px;
+            border-radius: 6px;
+            font-size: 13px;
+            font-weight: 500;
+            cursor: pointer;
+            border: none;
+        }
+
+        /* Stats bar - MUST be clickable, MUST show percentages */
+        .stat {
+            background: var(--surface);
+            padding: 10px 14px;
+            border-radius: 8px;
+            border: 1px solid var(--border);
+            cursor: pointer; /* clickable! */
+            display: flex;
+            align-items: baseline;
+            gap: 6px;
+        }
+        .stat:hover { border-color: var(--text-dim); }
+        .stat-value { font-size: 18px; font-weight: 600; }
+        .stat-pct { font-size: 12px; color: var(--text-dim); } /* show percentage */
+
+        /* Seniority - ONLY 4 LEVELS */
+        .seniority-exec { background: #a78bfa; color: #000; }
+        .seniority-director { background: #60a5fa; color: #000; }
+        .seniority-manager { background: #34d399; color: #000; }
+        .seniority-ic { background: #525252; color: #fff; }
+
+        /* Priority score - high/med/low */
+        .priority-high { background: var(--success); color: #000; }
+        .priority-med { background: var(--warning); color: #000; }
+        .priority-low { background: var(--text-dim); color: #fff; }
+
+        /* Warm path highlight */
+        .person-row.warm-path { background: var(--warm-glow); }
+        .warm-badge {
+            background: var(--warm);
+            color: #000;
+            font-size: 9px;
+            font-weight: 600;
+            padding: 2px 5px;
+            border-radius: 3px;
+            text-transform: uppercase;
+        }
+
+        /* Empty state - MUST have clear action */
+        .empty-state { padding: 48px 24px; text-align: center; }
+        .empty-state-action {
+            margin-top: 16px;
+            background: var(--accent);
+            color: #fff;
+            padding: 8px 16px;
+            border-radius: 6px;
+            border: none;
+            cursor: pointer;
+        }
+
+        /* Accessibility - visible focus */
+        :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    </style>
+</head>
+<body>
+    <!-- 1. Header -->
+    <div class="header">
+        <h1>{{COMPANY}} Organization</h1>
+        <p class="subtitle">{{CONTACT_COUNT}} contacts - Account map</p>
+    </div>
+
+    <!-- 2. Warm banner (show if warm connection exists) -->
+    <div class="warm-banner">
+        <span>🤝</span>
+        <div>
+            <strong>Warm path available:</strong>
+            You're connected to <span class="warm-banner-name">{{WARM_NAME}}</span> ({{WARM_TITLE}})
+        </div>
+        <button class="warm-banner-action" onclick="filterWarmPath()">Show warm connections</button>
+    </div>
+
+    <!-- 3. Controls: search + filters -->
+    <div class="controls">
+        <input type="text" class="search-box" placeholder="Search name, title, location...">
+        <div class="filter-group">
+            <button class="filter-btn active" data-filter="all">All</button>
+            <button class="filter-btn" data-filter="warm">Warm Path</button>
+            <button class="filter-btn" data-filter="exec">Executives</button>
+            <button class="filter-btn" data-filter="email">Has Email</button>
+        </div>
+    </div>
+
+    <!-- 4. Stats - clickable, with percentages -->
+    <div class="stats-bar">
+        <div class="stat" onclick="filter('all')">
+            <span class="stat-value">{{SHOWN}}</span>
+            <span class="stat-label">/ {{TOTAL}} shown</span>
+        </div>
+        <div class="stat" onclick="filter('email')">
+            <span class="stat-value">{{WITH_EMAIL}}</span>
+            <span class="stat-pct">{{EMAIL_PCT}}%</span>
+            <span class="stat-label">with email</span>
+        </div>
+        <div class="stat" onclick="filter('exec')">
+            <span class="stat-value">{{EXECS}}</span>
+            <span class="stat-pct">{{EXEC_PCT}}%</span>
+            <span class="stat-label">executives</span>
+        </div>
+    </div>
+
+    <!-- 5. Legend - only 4 levels -->
+    <div class="legend">
+        <span class="legend-item"><span class="dot" style="background:#a78bfa"></span> Executive</span>
+        <span class="legend-item"><span class="dot" style="background:#60a5fa"></span> Director</span>
+        <span class="legend-item"><span class="dot" style="background:#34d399"></span> Manager</span>
+        <span class="legend-item"><span class="dot" style="background:#525252"></span> IC</span>
+    </div>
+
+    <!-- 6. Main layout: sidebar + table -->
+    <div class="main-container">
+        <!-- Team sidebar (collapsed groups) -->
+        <div class="team-sidebar">
+            <h3>Teams</h3>
+            <div class="team-item active" data-team="all">All <span>{{TOTAL}}</span></div>
+            <!-- Generate team items dynamically -->
+        </div>
+
+        <!-- People table -->
+        <div class="people-container">
+            <div class="table-header">
+                <span>PRI</span>
+                <span>Name / Title</span>
+                <span>Team</span>
+                <span>Level</span>
+                <span>Contact</span>
+            </div>
+            <div id="peopleList">
+                <!-- Person rows rendered here -->
+            </div>
+        </div>
+    </div>
+
+    <script>
+    // Priority score calculation
+    function calcPriority(person) {
+        let score = 0;
+        if (['exec'].includes(person.display_seniority)) score += 40;
+        else if (['director'].includes(person.display_seniority)) score += 25;
+        else if (['manager'].includes(person.display_seniority)) score += 10;
+
+        if (person.email && !person.email.includes('not_unlocked')) score += 25;
+        if (person.phone) score += 10;
+        if (WARM_CONNECTIONS.has(person.name.toLowerCase())) score += 30;
+        return score;
+    }
+
+    // Keyboard shortcuts
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') closeModal();
+        if (e.key === '/' && e.target.tagName !== 'INPUT') {
+            e.preventDefault();
+            document.querySelector('.search-box').focus();
+        }
+    });
+
+    // Inject PEOPLE data here as JSON array
+    const PEOPLE = [/* ... */];
+    const WARM_CONNECTIONS = new Set([/* lowercase names */]);
+    </script>
+</body>
+</html>

--- a/skills/account-orgchart/skill-metadata.json
+++ b/skills/account-orgchart/skill-metadata.json
@@ -1,0 +1,28 @@
+{
+  "documents": {
+    "SKILL.md": {
+      "kind": "entrypoint",
+      "title": "Account Org Chart Builder",
+      "tags": [
+        "recipe",
+        "account-mapping",
+        "decision-makers"
+      ],
+      "providers": [
+        "leadmagic",
+        "dropleads",
+        "apollo",
+        "apify",
+        "peopledatalabs"
+      ]
+    },
+    "references/hierarchy-rules.md": {
+      "kind": "reference",
+      "title": "Hierarchy Inference Rules"
+    },
+    "references/orgchart-template.html": {
+      "kind": "template",
+      "title": "Org Chart HTML Template"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `account-orgchart` recipe for building interactive HTML org charts around a target person or company
- Recipe (not slash command) - users must ask for it explicitly, not added to marketplace.json
- Includes cost-optimal contact sourcing waterfall, seniority classification, warm intro highlighting

## What's included

- `skills/account-orgchart/SKILL.md` - Full pipeline with quick reference table
- `references/hierarchy-rules.md` - Seniority classification (13 internal levels -> 4 display levels) and manager prediction scoring
- `references/orgchart-template.html` - Design tokens and UI patterns (dark mode, warm path highlighting, priority scoring)

## Design decisions

- **Not auto-invoked**: Recipe pattern, not in marketplace.json skills array
- **4 display seniority levels** (exec, director, manager, IC) instead of 13 - reduces cognitive load
- **Priority score column** (0-100): +40 exec, +25 director, +10 manager, +25 email, +10 phone, +30 warm connection
- **Warm path highlighting**: Amber banner + badge + row glow for warm intro connections
- **Clickable stats with percentages**: "234 with email (18%)" filters on click

## Test plan

- [ ] Verify recipe can be read via `Read` tool when user asks "build me an org chart"
- [ ] Confirm skill is NOT auto-invoked (not in marketplace.json)
- [ ] Test pipeline commands execute correctly with Deepline CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)