### PR TITLE
examples: Harden warm-intro privacy checks

### DIFF
--- a/examples/office-hours/target-account-warm-intro-campaign/README.md
+++ b/examples/office-hours/target-account-warm-intro-campaign/README.md
@@ -728,10 +728,11 @@ rg -n -i 'bloomberry|crustdata.*linkedin' \
   examples/office-hours/target-account-warm-intro-campaign \
   examples/office-hours/warm-intro-scoring \
   examples/office-hours/warm-intro-ask-threads
-rg -n -i '@(gmail|yahoo|outlook|deepline|getaero)\.' \
+rg -n -i '[[:alnum:]._%+-]+@[[:alnum:].-]+\.[[:alpha:]]{2,}' \
   examples/office-hours/target-account-warm-intro-campaign \
   examples/office-hours/warm-intro-scoring \
-  examples/office-hours/warm-intro-ask-threads
+  examples/office-hours/warm-intro-ask-threads \
+  | rg -v -i '@([^[:space:]]*\.)?example\.(com|org|net)([^[:alnum:]]|$)|@[^[:space:]]*\.example([^[:alnum:]]|$)'
 rg -n -i 'linkedin\.(com|example)/in/' \
   examples/office-hours/target-account-warm-intro-campaign \
   examples/office-hours/warm-intro-scoring \
@@ -739,17 +740,14 @@ rg -n -i 'linkedin\.(com|example)/in/' \
   docs/superpowers/plans/2026-08-12-target-account-warm-intro-campaign.md \
   docs/superpowers/specs/2026-08-12-target-account-warm-intro-campaign-design.md \
   | rg -v 'linkedin\.(com|example)/in/(example-|[<{])'
-rg -n -i '6,484|94 enriched|680 experience|62 credits|869 days|\$1\.09|\$1\.20|stripe|modal|mongodb|google|harness|supaglue|porter|cisco thousandeyes|edges api|manpreet|ron\b|tiffany\b|george xing|carla colindres|spencer aller|mikiko bazeley|charlie vieth|ryan waldorf|cat yu|david siegel|gaurav tungatkar|target [abc]\b|connector [12]\b' \
-  examples/office-hours/warm-intro-scoring/README.md \
-  examples/office-hours/warm-intro-scoring/blog_post.md \
-  examples/office-hours/warm-intro-scoring/slide.html
-rg -n -i 'seniority|connection recency|double (credit|company|stripe|google)|acqui(hire|sition)' \
-  examples/office-hours/warm-intro-scoring/slide.html
 ```
 
 For scans where absence is required, ripgrep exit 1 with no output is success. The
 provider scan should match only explicit blocked-policy documentation, config, and
 tests in these three examples. `tenant-enum` is outside this workflow and retains
-its pre-existing provider note. The fixture smoke command above is the final
+its pre-existing provider note. Keep any organization-specific names, metrics,
+domains, or other denylist values in a private CI secret or local ignored file;
+never commit the sensitive values merely to scan for their absence. The fixture
+smoke command above is the final
 acceptance check. It must report zero provider calls and zero spend, decide every
 input account, and write all nine review/ledger artifacts.

--- a/examples/office-hours/target-account-warm-intro-campaign/tests/test_pipeline.py
+++ b/examples/office-hours/target-account-warm-intro-campaign/tests/test_pipeline.py
@@ -332,6 +332,38 @@ class FixturePipelineTests(unittest.TestCase):
                         violations.append(f"{path}:{slug}")
         self.assertEqual(violations, [])
 
+    def test_source_privacy_gate_allows_only_reserved_example_email_domains(self):
+        roots = (
+            PACKAGE_DIR,
+            PACKAGE_DIR.parent / "warm-intro-scoring",
+            PACKAGE_DIR.parent / "warm-intro-ask-threads",
+            PACKAGE_DIR.parents[2] / "docs" / "superpowers",
+        )
+        email = re.compile(
+            r"\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b",
+            re.IGNORECASE,
+        )
+        violations = []
+        for root in roots:
+            for path in root.rglob("*"):
+                if not path.is_file() or path.suffix not in {
+                    ".csv",
+                    ".html",
+                    ".json",
+                    ".md",
+                    ".py",
+                }:
+                    continue
+                text = path.read_text(encoding="utf-8", errors="replace")
+                for match in email.finditer(text):
+                    domain = match.group(1).casefold()
+                    if not (
+                        domain.endswith(".example")
+                        or domain in {"example.com", "example.org", "example.net"}
+                    ):
+                        violations.append(f"{path}:{match.group(0)}")
+        self.assertEqual(violations, [])
+
     def test_safe_alias_merge_remaps_foreign_keys_and_pdl_excludes_all_aliases(self):
         with TemporaryDirectory() as directory:
             root = Path(directory)

--- a/examples/office-hours/warm-intro-ask-threads/test_draft_asks.py
+++ b/examples/office-hours/warm-intro-ask-threads/test_draft_asks.py
@@ -251,7 +251,7 @@ class DraftGenerationTests(unittest.TestCase):
 
         drafts = module.draft_asks(
             rows=[row],
-            api_key="example-key",
+            api_key="example-key",  # pragma: allowlist secret
             top=None,
             model="example-model",
             verbose=False,
@@ -300,7 +300,7 @@ class DraftGenerationTests(unittest.TestCase):
 
         drafts = module.draft_asks(
             rows=[row],
-            api_key="example-key",
+            api_key="example-key",  # pragma: allowlist secret
             top=None,
             model="example-model",
             verbose=False,

--- a/examples/office-hours/warm-intro-ask-threads/test_send_via_linkedin.py
+++ b/examples/office-hours/warm-intro-ask-threads/test_send_via_linkedin.py
@@ -260,10 +260,10 @@ class IdempotencyTests(unittest.TestCase):
         module = load_module()
         expected_key = "".join(
             (
-                "307521be633e0a81",
-                "00a4c115d08093e7",
-                "59550f6e93d536a3",
-                "ea83c99515adfe89",
+                "307521be633e0a81",  # pragma: allowlist secret
+                "00a4c115d08093e7",  # pragma: allowlist secret
+                "59550f6e93d536a3",  # pragma: allowlist secret
+                "ea83c99515adfe89",  # pragma: allowlist secret
             )
         )
         key = _key(module, "path-approved")


### PR DESCRIPTION
## Summary

- remove a committed privacy denylist that contained real organization-specific names and prior-run metrics
- replace organization-specific email checks with a structural reserved-example-domain check
- add a source-level test requiring all workflow emails to use reserved `.example` domains
- annotate only audited test fixtures so `detect-secrets` can distinguish them from real credentials

## Verification

- campaign suite: 69 tests passed
- ask/drafter/sender suite: 47 tests passed
- Python compilation passed
- Ruff passed
- `git diff --check` passed
- scoped `detect-secrets`: 0 findings
- current-tree known-PII scan: 0 findings in the warm-intro workflow
- current-tree non-example email scan: 0 findings
